### PR TITLE
Fix OSV scanner: remove needs dependency

### DIFF
--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -367,7 +367,6 @@ jobs:
   # OSV Scanner for dependency vulnerabilities
   osv-scanner:
     runs-on: ubuntu-latest
-    needs: validate
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
OSV scanner job needed 'validate' which is skipped when no image changes. Removed dependency so it always runs.